### PR TITLE
Import SSL certificates into Mono trust store

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM alpine:3.7
 
-RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing && \
+    apk add --update --no-cache ca-certificates && \
+    cert-sync /etc/ssl/certs/ca-certificates.crt && \
+    apk del ca-certificates


### PR DESCRIPTION
Import the default SSL root certificates into the Mono trust store, so that connecting to https services works out-of-the-box.

Fixes #7 